### PR TITLE
Fix issue 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/eth-event)
+### Fixed
+- Handle dynamic and fixed size tuples
 
 ## [1.2.0](https://github.com/iamdefinitelyahuman/eth-event/releases/tag/v1.2.0) - 2020-07-14
 ### Added

--- a/eth_event/main.py
+++ b/eth_event/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from typing import Dict, List
 import re
+from typing import Dict, List
 
 from eth_abi import decode_abi, decode_single
 from eth_abi.exceptions import InsufficientDataBytes, NonEmptyPaddingBytes

--- a/eth_event/main.py
+++ b/eth_event/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from typing import Dict, List
+import re
 
 from eth_abi import decode_abi, decode_single
 from eth_abi.exceptions import InsufficientDataBytes, NonEmptyPaddingBytes
@@ -279,11 +280,18 @@ def decode_traceTransaction(
 
 def _params(abi_params: List) -> List:
     types = []
+    # regex with 2 capturing groups
+    # first group captures whether this is an array tuple
+    # second group captures the size if this is a fixed size tuple
+    pattern = re.compile(r"tuple(\[(\d*)\])?")
     for i in abi_params:
-        if i["type"] != "tuple":
-            types.append(i["type"])
+        tuple_match = pattern.match(i["type"])
+        if tuple_match:
+            _array, _size = tuple_match.group(1, 2)  # unpack the captured info
+            tuple_type_tail = f"[{_size}]" if _array is not None else ""
+            types.append(f"({','.join(x for x in _params(i['components']))}){tuple_type_tail}")
             continue
-        types.append(f"({','.join(x for x in _params(i['components']))})")
+        types.append(i["type"])
 
     return types
 

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -24,3 +24,39 @@ def test_get_log_topic_contract_abi(abi):
 def test_event_abi(abi):
     result = get_topic_map(abi)
     assert len(result) + 2 == len(abi)
+
+
+def test_get_log_topic_for_event_with_dynamic_tuple_size_inputs():
+    event_abi = {
+        "name": "DynamicTupleEvent",
+        "type": "event",
+        "anonymous": False,
+        "inputs": [
+            {
+                "name": "_foo",
+                "type": "tuple[]",
+                "indexed": False,
+                "components": [{"name": "x", "type": "string"}, {"name": "y", "type": "bytes4[]"}],
+            }
+        ],
+    }
+    result = get_log_topic(event_abi)
+    assert result == "0xa51b9362db3864a3b79228fc175c8781b95be6435ed9b0528c89ec769e033e34"
+
+
+def test_get_log_topic_for_event_with_fixed_tuple_size_inputs():
+    event_abi = {
+        "name": "DynamicTupleEvent",
+        "type": "event",
+        "anonymous": False,
+        "inputs": [
+            {
+                "name": "_foo",
+                "type": "tuple[2]",
+                "indexed": False,
+                "components": [{"name": "x", "type": "string"}, {"name": "y", "type": "bytes4[]"}],
+            }
+        ],
+    }
+    result = get_log_topic(event_abi)
+    assert result == "0xa95e22675fbb9c0598f6c3ef02d12b0a8ac59f6b56d9210a5e9f085971384e7a"


### PR DESCRIPTION
### What I did
I changed the logic in the `eth_event/main.py::_params` function to handle tuples of fixed or dynamic size.

Related issue: #15 eth-brownie/brownie#955

### How I did it
Using the standard library `re` module, I added a simple regular expression which when matched against a type string, captures
whether the tuple is a dynamic or fixed size array.

### How to verify it
One can verify the work by running the command `pytest`.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation (README.md)
- [x] I have added an entry to the changelog
