### PR TITLE
Handle indexed tuples

### DIFF
--- a/eth_event/main.py
+++ b/eth_event/main.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict, List
 
 from eth_abi import decode_abi, decode_single
-from eth_abi.exceptions import InsufficientDataBytes, NonEmptyPaddingBytes
+from eth_abi.exceptions import InsufficientDataBytes, NoEntriesFound, NonEmptyPaddingBytes
 from eth_hash.auto import keccak
 from eth_utils import to_checksum_address
 from hexbytes import HexBytes
@@ -349,7 +349,7 @@ def _decode(inputs: List, topics: List, data: str) -> List:
             encoded = HexBytes(topics.pop())
             try:
                 value = decode_single(i["type"], encoded)
-            except (InsufficientDataBytes, OverflowError):
+            except (InsufficientDataBytes, NoEntriesFound, OverflowError):
                 # an array or other data type that uses multiple slots
                 result[-1].update({"value": encoded.hex(), "decoded": False})
                 continue


### PR DESCRIPTION
### What I did
Correctly handle indexed tuples when decoding an event.

Fixes https://github.com/eth-brownie/brownie/issues/1042

### How I did it
An indexed tuple produces a hash in the same way as any other indexed type >32 bytes. This fails to decode with `eth_abi` by raising `NoEntriesFound`. By catching this error we are able to gracefully handle the inability to decode, in the same way we handle strings or bytes.
