### PR TITLE
v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project are documented in this file.
 This changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/iamdefinitelyahuman/eth-event)\
+## [Unreleased](https://github.com/iamdefinitelyahuman/eth-event)
+
+## [1.2.5](https://github.com/iamdefinitelyahuman/eth-event/releases/tag/v1.2.5) - 2024-02-02
+### Fixed
+- Loosen dependencies
+- Revert to `hexbytes<1`
 
 ## [1.2.4](https://github.com/iamdefinitelyahuman/eth-event/releases/tag/v1.2.4) - 2024-01-31
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eth-event
 
-[![Pypi Status](https://img.shields.io/pypi/v/eth-event.svg)](https://pypi.org/project/eth-event/) [![Build Status](https://img.shields.io/github/workflow/status/iamdefinitelyahuman/eth-event/main%20workflow)](https://github.com/iamdefinitelyahuman/eth-event/actions) [![Coverage Status](https://img.shields.io/codecov/c/github/iamdefinitelyahuman/eth-event)](https://codecov.io/gh/iamdefinitelyahuman/eth-event)
+[![Pypi Status](https://img.shields.io/pypi/v/eth-event.svg)](https://pypi.org/project/eth-event/) [![Build Status](https://img.shields.io/github/actions/workflow/status/iamdefinitelyahuman/eth-event/main.yaml?branch=master)](https://github.com/iamdefinitelyahuman/eth-event/actions) [![Coverage Status](https://img.shields.io/codecov/c/github/iamdefinitelyahuman/eth-event)](https://codecov.io/gh/iamdefinitelyahuman/eth-event)
 
 Tools for Ethereum event decoding and topic generation.
 

--- a/eth_event/main.py
+++ b/eth_event/main.py
@@ -299,8 +299,8 @@ def decode_traceTransaction(
 
 
 def _0xstring(value: bytes) -> str:
-    # prepend bytes with 0x to avoid a breaking change from HexBytes v1
-    return f"0x{HexBytes(value).hex()}"
+    # placeholder, will be used to prepend bytes with 0x to avoid HexBytes v1 breaking change
+    return f"{HexBytes(value).hex()}"
 
 
 def _params(abi_params: List) -> List:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.4
+current_version = 1.2.5
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6, <4",
     install_requires=[
-        "eth-abi>=5,<6",
+        "eth-abi>=4,<6",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
-        "eth-utils>=3,<4",
-        "hexbytes>=1,<2",
+        "eth-utils>=2,<4",
+        "hexbytes<1",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="eth-event",
-    version="1.2.4",  # do not edit directly, use bumpversion
+    version="1.2.5",  # do not edit directly, use bumpversion
     license="MIT",
     description="Ethereum event decoder and topic generator",
     long_description=long_description,


### PR DESCRIPTION
### What I did
Revert to using `hexbytes<1.0.0`.  The latest `web3` release doesn't yet target it, so that makes the `eth-event==1.2.4` release basically unuseable due to conflicts.  My bad.

Generally, this release also loosens dependencies as much as possible.