### PR TITLE
Update to eth-abi >= 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/eth-event)
+### Fixed
+- Compatibility with eth-abi >= 5.0.1
 
 ## [1.2.5](https://github.com/iamdefinitelyahuman/eth-event/releases/tag/v1.2.5) - 2024-02-02
 ### Fixed

--- a/eth_event/main.py
+++ b/eth_event/main.py
@@ -5,6 +5,11 @@ from typing import Dict, List
 
 import eth_abi
 from eth_abi.exceptions import InsufficientDataBytes, NoEntriesFound, NonEmptyPaddingBytes
+try:
+    from eth_abi.exceptions import InvalidPointer
+except ImportError:
+    # Define a stub exception for older eth-abi versions
+    InvalidPointer = type('InvalidPointer', (Exception,), {})
 from eth_hash.auto import keccak
 from eth_utils import to_checksum_address
 from hexbytes import HexBytes
@@ -358,6 +363,8 @@ def _decode(inputs: List, topics: List, data: str) -> List:
         raise EventError("Event data has insufficient length")
     except NonEmptyPaddingBytes:
         raise EventError("Malformed data field in event log")
+    except InvalidPointer as e:
+        raise EventError(str(e))
     except OverflowError:
         raise EventError("Cannot decode event due to overflow error")
 


### PR DESCRIPTION
### What I did
Adjusted compatibility with a recent eth-abi version.

Related issue: ethereum/eth-abi#226.

### How I did it
When I upgraded Python Ethereum stack to a recent versions I've found that eth-event is not passing the `test_decode_overflow`  test due to a new exception.

### How to verify it
Run tests with eth-abi 5.0.0 and any higher version with and without this patch.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [x] I have added an entry to the changelog
