### PR TITLE
chore: bump version to 1.2.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.7
+current_version = 1.2.8
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="eth-event",
-    version="1.2.7",  # do not edit directly, use bumpversion
+    version="1.2.8",  # do not edit directly, use bumpversion
     license="MIT",
     description="Ethereum event decoder and topic generator",
     long_description=long_description,


### PR DESCRIPTION
### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
