### PR TITLE
chore: loosen cchecksum pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     package_data={"eth_event": ["py.typed"]},
     python_requires=">=3.8,<4",
     install_requires=[
-        "cchecksum>=0.2.6,<0.3",
+        "cchecksum>=0.2.6,<0.4",
         "eth-abi>=4,<6",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "hexbytes>=1,<2",


### PR DESCRIPTION
0.3 does more stuff without holding the GIL for better multithreading performance

### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
