### PR TITLE
chore: add eth-abi to build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "mypy[mypyc]>=1.14.1,<1.17.1"]
+requires = ["setuptools", "wheel", "mypy[mypyc]>=1.14.1,<1.17.1", "eth-abi>=4,<6"]
 
 
 # Black configuration


### PR DESCRIPTION
this will ensure eth-abi and eth-typing are both installed at build time, allowing mypyc to optimize eth-event C code using their type hints

### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
