### PR TITLE
fix: include faster-eth-abi in build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "mypy[mypyc]>=1.14.1,<1.18.3", "eth-abi>=4,<6"]
+requires = ["setuptools", "wheel", "mypy[mypyc]>=1.14.1,<1.18.3", "faster-eth-abi>=4,<6"]
 
 
 # Black configuration


### PR DESCRIPTION
I forgot to update this when we upgraded the actual dependency. It changes nothing but should be corrected.