### PR TITLE
fix(mypy): fix incorrect hint for EventData.value

### DIFF
--- a/eth_event/main.py
+++ b/eth_event/main.py
@@ -65,8 +65,8 @@ class UnknownEvent(Exception):
 class EventData(TypedDict, total=False):
     name: str
     type: str
-    components: NotRequired[Sequence[ABIComponent]]  # TODO: define a typed dict for components
-    value: HexStr
+    components: NotRequired[Sequence[ABIComponent]]
+    value: Any
     decoded: bool
 
 


### PR DESCRIPTION
The EventData TypedDict's `value` hint is currently incorrect. The current type, HexStr is not correct here because `eth_abi.decode` can return values of any type, which are then added to the dict.

This PR fixes the EventData TypedDict accordingly.