### PR TITLE
ci: add manylinux i686 wheels to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            build_type: manylinux-x64
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: x86_64
+            artifact_name: wheels-ubuntu-latest-manylinux-x64
+
+          - os: ubuntu-latest
+            build_type: manylinux-x86
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: i686
+            artifact_name: wheels-ubuntu-latest-manylinux-x86
+
+          - os: ubuntu-latest
+            build_type: musllinux-x64
+            cibw_build: "*musllinux*"
+            cibw_archs_linux: x86_64
+            artifact_name: wheels-ubuntu-latest-musllinux-x64
+
+          - os: macos-latest
+            build_type: macos
+            cibw_build: ""
+            cibw_archs_linux: ""
+            artifact_name: wheels-macos-latest
+
+          - os: windows-latest
+            build_type: windows
+            cibw_build: ""
+            cibw_archs_linux: ""
+            artifact_name: wheels-windows-latest
 
     steps:
       - name: Check out code
@@ -33,12 +62,15 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel cibuildwheel mypy[mypyc] -r requirements.txt
 
       - name: Build wheels
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || '' }}
+          CIBW_BUILD: ${{ matrix.cibw_build || '' }}
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: ${{ matrix.artifact_name }}
           path: wheelhouse/*.whl
 
   publish_sdist_and_wheels:
@@ -70,11 +102,23 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist
 
-      - name: Download wheel artifacts (Ubuntu)
+      - name: Download manylinux 64-bit wheels
         uses: actions/download-artifact@v4
         with:
-          name: "wheels-ubuntu-latest"
-          path: wheelhouse/ubuntu
+          name: "wheels-ubuntu-latest-manylinux-x64"
+          path: wheelhouse/linux-many-x64
+
+      - name: Download manylinux 32-bit wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: "wheels-ubuntu-latest-manylinux-x86"
+          path: wheelhouse/linux-many-x86
+
+      - name: Download musllinux 64-bit wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: "wheels-ubuntu-latest-musllinux-x64"
+          path: wheelhouse/linux-musl-x64
 
       - name: Download wheel artifacts (macOS)
         uses: actions/download-artifact@v4
@@ -96,6 +140,8 @@ jobs:
         run: |
           twine upload \
             dist/* \
-            wheelhouse/ubuntu/*.whl \
+            wheelhouse/linux-many-x64/*.whl \
+            wheelhouse/linux-many-x86/*.whl \
+            wheelhouse/linux-musl-x64/*.whl \
             wheelhouse/macos/*.whl \
             wheelhouse/windows/*.whl

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.8
+current_version = 1.4.9
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md") as fh:
 
 setup(
     name="eth-event",
-    version="1.4.8",  # do not edit directly, use bumpversion
+    version="1.4.9",  # do not edit directly, use bumpversion
     license="MIT",
     description="Ethereum event decoder and topic generator",
     long_description=long_description,


### PR DESCRIPTION
- split the Linux release build into explicit manylinux x64, manylinux i686, and musllinux x64 artifact legs
- publish the new manylinux i686 wheel artifact alongside the existing release wheels
- bump the package version to `1.4.9`