### PR TITLE
fix(packaging): remove deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary

Remove the deprecated MIT license classifier from package metadata.

## Rationale

Recent setuptools packaging emits a warning asking projects to remove license classifiers in favor of SPDX license expressions. `eth-event` already declares `license="MIT"`, so the redundant classifier can be removed.

## Details

- Remove `License :: OSI Approved :: MIT License` from `setup.py`.
- Preserve the existing `license="MIT"` metadata.
- No runtime code changes.